### PR TITLE
fix: align driver with Universal Resolver spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is a [Universal Resolver](https://github.com/decentralized-identity/univers
 ## Example DIDs
 
 ```
-did:x:zQ3shoiydFD6jdTdXLPProPZWL6igg9bCyaJY6zEKqQoNE96C
+did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k
 ```
 
 ## Development
@@ -27,7 +27,7 @@ Start development server: `yarn start`
 By default it will be running on port `8080` - it should connect to the blockchain node and be ready to serve DIDs at that endpoint. Example:
 
 ```
-curl http://localhost:8080/1.0/identifiers/did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeob4jFQmtU6sxr4XWTZzUA
+curl http://localhost:8080/1.0/identifiers/did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k
 ```
 
 ## Build and usage
@@ -54,7 +54,7 @@ curl http://localhost:8080/1.0/identifiers/did:dock:5CDsD8HZa6TeSfgmMcxAkbSXYWeo
    docker exec -it ixo-did-resolver /bin/sh
    ```
 
-1. The server responds at `/1.0/identifiers/<DID with method, like did:x:...>`
+1. The server responds at `/1.0/identifiers/<DID with method, like did:ixo:...>`
 
 ## Driver Environment Variables
 

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Controller, Get, Header, Param, Res } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
 import { AppService } from './app.service';
 
 @ApiTags('DID Resolution')
@@ -13,7 +14,22 @@ export class AppController {
   }
 
   @Get('/1.0/identifiers/:did')
-  getDid(@Param('did') did: string) {
-    return this.appService.getDid(did);
+  @Header('Content-Type', 'application/did+ld+json')
+  async getDid(
+    @Param('did') did: string,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const result = await this.appService.getDid(did);
+
+    const error = result?.didResolutionMetadata?.error;
+    if (error === 'notFound') {
+      res.status(404);
+    } else if (error === 'invalidDid') {
+      res.status(400);
+    } else if (error) {
+      res.status(500);
+    }
+
+    return result;
   }
 }

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -40,7 +40,7 @@ export class IxoResolver {
         // '@context': 'https://w3id.org/did-resolution/v1',
         didResolutionMetadata: {
           contentType: 'application/did+ld+json',
-          pattern: '^did:(?x:|ixo:).+$',
+          pattern: '^did:(?:x|ixo):.+$',
         },
         didDocument: null,
         didDocumentMetadata: {},
@@ -61,7 +61,7 @@ export class IxoResolver {
         console.error({ error });
         // if error return with resolution metadata not found
         didResolution.didResolutionMetadata = {
-          error: 'invalidDid',
+          error: 'notFound',
           retrieved: new Date(),
           message: `Can't resolve did: ${parsed.did}`,
           did: parsed,


### PR DESCRIPTION
  - Set Content-Type to application/did+ld+json
  - Return HTTP 404 with notFound error code on missing DIDs
  - Correct malformed pattern regex
  - Update README example to did:ixo:ixo1rl9vhhxg0t7ywlh953gtthphg889v7d3e2gx7k