### PR TITLE
fix: strip sub-second precision from created/updated

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,6 +22,14 @@ export const updateObjectStrings = (
 };
 
 /**
+ * Format a Date as an ISO 8601 string in UTC with no sub-second precision,
+ * as required by W3C DID Core §7.1.3 for didDocumentMetadata datetime
+ * values (e.g. `2026-03-09T05:11:03Z`, not `...03.719Z`).
+ */
+export const toDidCoreDatetime = (date: Date): string =>
+  date.toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+/**
  * Recursively renames every occurrence of `oldKey` to `newKey` on plain objects.
  * Used to canonicalise chain proto field names (e.g. `blockchainAccountID`)
  * to their DID-compatible JSON casing (`blockchainAccountId`).

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,7 +1,7 @@
 import { createQueryClient, utils } from '@ixo/impactxclient-sdk';
 import { QueryIidDocumentResponse } from '@ixo/impactxclient-sdk/types/codegen/ixo/iid/v1beta1/query';
 import { DidResolution, QueryClientType } from './types';
-import { renameKeyDeep, updateObjectStrings } from './helpers';
+import { renameKeyDeep, toDidCoreDatetime, updateObjectStrings } from './helpers';
 
 const W3C_DID_CONTEXT = 'https://www.w3.org/ns/did/v1';
 const IXO_IID_CONTEXT = 'https://w3id.org/ixo/ns/interchain-identifiers/v1';
@@ -95,12 +95,14 @@ export class IxoResolver {
       ];
       delete didDoc.iidDocument.context;
 
-      // convert Timestamp to js dates
-      didDoc.iidDocument.metadata.created = utils.proto.fromTimestamp(
-        didDoc.iidDocument.metadata.created,
+      // Convert protobuf Timestamp to ISO 8601 strings WITHOUT sub-second
+      // precision, as required by W3C DID Core §7.1.3 for didDocumentMetadata
+      // `created` / `updated`.
+      didDoc.iidDocument.metadata.created = toDidCoreDatetime(
+        utils.proto.fromTimestamp(didDoc.iidDocument.metadata.created),
       ) as any;
-      didDoc.iidDocument.metadata.updated = utils.proto.fromTimestamp(
-        didDoc.iidDocument.metadata.updated,
+      didDoc.iidDocument.metadata.updated = toDidCoreDatetime(
+        utils.proto.fromTimestamp(didDoc.iidDocument.metadata.updated),
       ) as any;
       // assign metadata that returned on didDoc from registry to response metadata
       didResolution.didDocumentMetadata = Object.assign(


### PR DESCRIPTION
  DID Core §7.1.3 forbids fractional seconds in didDocumentMetadata
  datetime values.